### PR TITLE
More reliable homedir detection

### DIFF
--- a/app/aux.js
+++ b/app/aux.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var os = require('os');
 var path = require('path');
 
 class AUX {
@@ -22,7 +23,7 @@ class AUX {
    * @returns {void|string|XML|*}
    */
   static expandTilde (strPath) {
-    return strPath.replace('~', process.env.HOME || process.env.USERPROFILE)
+    return strPath.replace('~', os.homedir());
   }
 
   /**
@@ -75,3 +76,4 @@ class AUX {
 }
 
 module.exports = AUX;
+


### PR DESCRIPTION
By using node's supplied `os.homedir()` you don't need to look for a specific env vars or call sys calls
to determine correct user dir.

https://github.com/libuv/libuv/blob/193a6f9b93b8b50f9fa9290b207a3513480c4f94/src/unix/core.c#L1023
https://github.com/libuv/libuv/blob/e397caa3a6a139fff2fed06e0223ee92582fa2d2/src/win/util.c#L1108
